### PR TITLE
add playcount_offset and change where needed

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -5,6 +5,7 @@ import discord
 from discord.ext import commands
 
 from db import database
+from db.migration_controller import run_migrations
 
 
 # Bot setup
@@ -72,10 +73,12 @@ async def main():
         if not TOKEN:
             raise EnvironmentError("DISCORD_BOT_TOKEN environment variable is missing.")
 
+        # Migrate DB
+        run_migrations()
+
         database.initialize_database()
         await load_cogs()
         await bot.start(TOKEN)
-
 
 # Use asyncio to call the main function
 asyncio.run(main())

--- a/cogs/add_game.py
+++ b/cogs/add_game.py
@@ -4,7 +4,7 @@ import discord
 from discord import Interaction
 from discord.ext import commands
 
-from db.database import add_game_to_db
+from db.database import add_game_to_db, get_least_playcount_for_server
 from db.models import Game
 
 
@@ -24,18 +24,23 @@ class AddGameCommand(commands.Cog):
 
         server_id = str(interaction.guild.id)
         try:
+            playcount_offset = get_least_playcount_for_server(server_id)
+
             game = Game(
                 server_id=server_id,
                 name=name,
                 min_players=min_players,
                 max_players=max_players,
                 steam_link=steam_link,
-                banner_link=banner_link
+                banner_link=banner_link,
+                playcount_offset=playcount_offset
             )
             add_game_to_db(game)
             await interaction.response.send_message(f"'{name}' has been added to t’list!")
         except sqlite3.IntegrityError:
             await interaction.response.send_message("Error: Game already exists.")
+        except Exception as e:
+            print(e)
 
 
 # Setup function to add the cog to the bot

--- a/cogs/add_game.py
+++ b/cogs/add_game.py
@@ -39,8 +39,6 @@ class AddGameCommand(commands.Cog):
             await interaction.response.send_message(f"'{name}' has been added to t’list!")
         except sqlite3.IntegrityError:
             await interaction.response.send_message("Error: Game already exists.")
-        except Exception as e:
-            print(e)
 
 
 # Setup function to add the cog to the bot

--- a/cogs/choose_game.py
+++ b/cogs/choose_game.py
@@ -42,9 +42,8 @@ def pick_game(games: List[GameWithPlayHistory], exclude_game_id: str = None, ign
 tuple[List[GameWithPlayHistory], GameWithPlayHistory]:
     if not ignore_choosing_least_played:
         # Filter games to include only those with the least  number of times played
-        # Assuming the 5th element (index 4) is the play count
-        min_play_count = min(len(game.play_history) for game in games)  # Find the minimum play count
-        games = [game for game in games if len(game.play_history) == min_play_count]  # Only include least played games
+        min_play_count = min(len(game.play_history) + game.playcount_offset for game in games)  # Find the minimum play count
+        games = [game for game in games if (len(game.play_history) + game.playcount_offset) == min_play_count]  # Only include least played games
 
     # If there's only one game left in the list after filtering, and it's the one we excluded, return it
     if len(games) == 1 and exclude_game_id and games[0].id == exclude_game_id:

--- a/db/database.py
+++ b/db/database.py
@@ -99,6 +99,7 @@ def fetch_game_with_memory(server_id: str, name: str) -> Optional[GameWithPlayHi
             max_players=game.max_players,
             steam_link=game.steam_link,
             banner_link=game.banner_link,
+            playcount_offset=game.playcount_offset,
             play_history=play_history
         )
 
@@ -139,6 +140,7 @@ def get_all_server_games(server_id: str) -> List[GameWithPlayHistory]:
                 max_players=game.max_players,
                 steam_link=game.steam_link,
                 banner_link=game.banner_link,
+                playcount_offset=game.playcount_offset,
                 play_history=history_map.get(game.id, [])
             ))
 
@@ -202,3 +204,19 @@ def mark_game_logs_as_ignored(server_id: str, game_name: str, memory_date: Optio
         session.commit()
 
         return updated_count > 0
+
+
+def get_least_playcount_for_server(server_id: str) -> int:
+    """
+    Returns the lowest number of play history entries for any game in the server.
+    If no games exist or none have play history, returns 0.
+    """
+    games: list[GameWithPlayHistory] = get_all_server_games(server_id)
+
+    if not games:
+        return 0
+
+    # Get play counts
+    play_counts = [len(game.play_history) for game in games]
+
+    return min(play_counts) if play_counts else 0

--- a/db/migration_controller.py
+++ b/db/migration_controller.py
@@ -1,0 +1,25 @@
+import importlib
+import os
+import sqlite3
+
+from db.database import DB_PATH
+
+
+def get_migration_modules():
+    migration_dir = os.getcwd() + "/db/migrations"
+    files = sorted(f for f in os.listdir(migration_dir) if f.endswith(".py") and f[0:3].isdigit())
+
+    for file in files:
+        module_name = f"db.migrations.{file[:-3]}"
+        yield importlib.import_module(module_name)
+
+
+def run_migrations():
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        for module in get_migration_modules():
+            print(f"Running {module.__name__}")
+            module.run_migration(conn)
+    finally:
+        conn.close()
+

--- a/db/migrations/001_add_playcount.py
+++ b/db/migrations/001_add_playcount.py
@@ -1,0 +1,11 @@
+def run_migration(conn):
+    cursor = conn.cursor()
+    cursor.execute("PRAGMA table_info(game_list);")
+    columns = [row[1] for row in cursor.fetchall()]
+
+    if "playcount_offset" not in columns:
+        print("Applying migration: Add playcount_offset")
+        cursor.execute("ALTER TABLE game_list ADD COLUMN playcount_offset INTEGER DEFAULT 0;")
+        conn.commit()
+    else:
+        print("Migration skipped: playcount_offset already exists")

--- a/db/models.py
+++ b/db/models.py
@@ -17,6 +17,7 @@ class GameWithPlayHistory:
     max_players: int
     steam_link: Optional[str]
     banner_link: Optional[str]
+    playcount_offset: int
     play_history: List[datetime]
 
     def __eq__(self, other):
@@ -37,6 +38,7 @@ class Game(Base):
     min_players = Column(Integer, nullable=False)
     max_players = Column(Integer, nullable=False)
     banner_link = Column(Text, nullable=True)
+    playcount_offset = Column(Integer, nullable=False, default=0, server_default="0")
 
     logs = relationship("GameLog", back_populates="game", cascade="all, delete-orphan")
 


### PR DESCRIPTION
The problem:
When adding a new game to the wheel, it has a play count of 0 (obvs). This means that if all games have > 0 playcount, then the wheel will ONLY be the new game(s) until the playcount gets up to the minimum of the already existing games. 

To counter this, we need to store a "playcount_offset" when a game is added. This is the value of the minimum playcount of all games in the server so that it joins the current wheel of games.