### PR TITLE
Add Nuke command to reset play count for all games

### DIFF
--- a/cogs/nuke.py
+++ b/cogs/nuke.py
@@ -57,12 +57,6 @@ class NukeConfirmationView(ui.View):
                 embed=embed,
                 view=None
             )
-
-            await interaction.response.edit_message(
-                content="Nuke approved and executed.",
-                embed=None,
-                view=None
-            )
         else:
             await interaction.response.edit_message(
                 content="There was a problem resetting the playcounts. Please check logs and report errors or try again.",

--- a/cogs/nuke.py
+++ b/cogs/nuke.py
@@ -95,14 +95,13 @@ class NukeCog(commands.Cog):
         # Send confirmation message with buttons
         embed = discord.Embed(
             title="Are you sure you want to nuke all playcounts?",
-            description="This will reset the played count for all games to zero, allowing the wheel to show all games equally. Play history will be preserved but ignored. Proceed with caution.",
+            description="This will reset the played count for all games to zero, allowing the wheel to show all games equally. Play history will be preserved but ignored. Proceed with caution. This request must be approved by another server member.",
             color=discord.Color.red()
         )
         embed.add_field(name="Requested by", value=interaction.user.display_name, inline=True)
         await interaction.response.send_message(
             embed=embed,
-            view=view,
-            ephemeral=True
+            view=view
         )
 
 

--- a/cogs/nuke.py
+++ b/cogs/nuke.py
@@ -26,10 +26,23 @@ class NukeConfirmationView(ui.View):
 
         # Acknowledge the action
         if result:
-            # Create public success embed
+            ascii_art = """```
+     _.-^^---....,,--       
+ _--                  --_  
+<                        >)
+|                         | 
+ \._                   _./  
+    '''--. . , ; .--'''       
+          | |   |             
+       .-=||  | |=-.   
+       `-=#$%&%$#=-'   
+          | ;  :|     
+ _____.,-#%&$@%#&#~,._____```
+"""
             embed = discord.Embed(
                 title="Playcounts Nuked",
-                description="All playcounts have been reset to zero. The wheel will now show all games equally.",
+                description="All playcounts have been reset to zero. The wheel will now show all games equally."
+                            f"{ascii_art}",
                 color=discord.Color.green()
             )
             embed.add_field(name="Requested by", value=self.requester_name, inline=True)
@@ -40,7 +53,10 @@ class NukeConfirmationView(ui.View):
             )
 
             # Send public message
-            await interaction.channel.send(embed=embed)
+            await interaction.response.edit_message(
+                embed=embed,
+                view=None
+            )
 
             await interaction.response.edit_message(
                 content="Nuke approved and executed.",
@@ -57,7 +73,7 @@ class NukeConfirmationView(ui.View):
     @discord.ui.button(label="No, cancel", style=discord.ButtonStyle.secondary)
     async def cancel(self, interaction: Interaction, button: Button):
         await interaction.response.edit_message(
-            content="Nuke canceled.",
+            content="Nuke cancelled.",
             embed=None,
             view=None
         )

--- a/cogs/nuke.py
+++ b/cogs/nuke.py
@@ -1,0 +1,70 @@
+import discord
+from discord import Interaction, ui
+from discord.ext import commands
+from discord.ui import Button
+
+from db.database import nuke_playcounts
+
+
+# Confirmation View with Buttons
+class NukeConfirmationView(ui.View):
+    def __init__(self, server_id: str):
+        super().__init__()
+        self.server_id = server_id
+
+    @discord.ui.button(label="Yes, nuke all playcounts", style=discord.ButtonStyle.danger)
+    async def confirm(self, interaction: Interaction, button: Button):
+        # Call the function to nuke playcounts
+        result = nuke_playcounts(self.server_id)
+
+        # Acknowledge the action
+        if result:
+            await interaction.response.edit_message(
+                content="All playcounts have been reset to zero. The wheel will now show all games equally.",
+                embed=None,
+                view=None
+            )
+        else:
+            await interaction.response.edit_message(
+                content="There was a problem resetting the playcounts. Please check logs and report errors or try again.",
+                embed=None,
+                view=None
+            )
+
+    @discord.ui.button(label="No, cancel", style=discord.ButtonStyle.secondary)
+    async def cancel(self, interaction: Interaction, button: Button):
+        await interaction.response.edit_message(
+            content="Nuke canceled.",
+            embed=None,
+            view=None
+        )
+
+
+class NukeCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    # Command to nuke all playcounts
+    @discord.app_commands.command(name="nuke", description="Reset all played counts to zero for a fresh wheel")
+    async def nuke(self, interaction: Interaction):
+        """Reset all played counts to zero, allowing the wheel to show all games equally."""
+        server_id = str(interaction.guild.id)
+
+        # Create the confirmation view
+        view = NukeConfirmationView(server_id)
+
+        # Send confirmation message with buttons
+        await interaction.response.send_message(
+            embed=discord.Embed(
+                title="Are you sure you want to nuke all playcounts?",
+                description="This will reset the played count for all games to zero, allowing the wheel to show all games equally. Play history will be preserved but ignored. Proceed with caution.",
+                color=discord.Color.red()
+            ),
+            view=view,
+            ephemeral=True
+        )
+
+
+# Add the cog to the bot
+async def setup(bot):
+    await bot.add_cog(NukeCog(bot))

--- a/cogs/nuke.py
+++ b/cogs/nuke.py
@@ -8,19 +8,42 @@ from db.database import nuke_playcounts
 
 # Confirmation View with Buttons
 class NukeConfirmationView(ui.View):
-    def __init__(self, server_id: str):
+    def __init__(self, server_id: str, requester_id: int, requester_name: str):
         super().__init__()
         self.server_id = server_id
+        self.requester_id = requester_id
+        self.requester_name = requester_name
 
     @discord.ui.button(label="Yes, nuke all playcounts", style=discord.ButtonStyle.danger)
     async def confirm(self, interaction: Interaction, button: Button):
+        # Check if the presser is the requester
+        if interaction.user.id == self.requester_id:
+            await interaction.response.send_message("You cannot approve your own nuke request.", ephemeral=True)
+            return
+
         # Call the function to nuke playcounts
         result = nuke_playcounts(self.server_id)
 
         # Acknowledge the action
         if result:
+            # Create public success embed
+            embed = discord.Embed(
+                title="Playcounts Nuked",
+                description="All playcounts have been reset to zero. The wheel will now show all games equally.",
+                color=discord.Color.green()
+            )
+            embed.add_field(name="Requested by", value=self.requester_name, inline=True)
+            embed.add_field(name="Approved by", value=interaction.user.display_name, inline=True)
+            embed.set_footer(
+                text=f"Executed by {interaction.user.display_name}",
+                icon_url=interaction.user.display_avatar.url
+            )
+
+            # Send public message
+            await interaction.channel.send(embed=embed)
+
             await interaction.response.edit_message(
-                content="All playcounts have been reset to zero. The wheel will now show all games equally.",
+                content="Nuke approved and executed.",
                 embed=None,
                 view=None
             )
@@ -51,15 +74,17 @@ class NukeCog(commands.Cog):
         server_id = str(interaction.guild.id)
 
         # Create the confirmation view
-        view = NukeConfirmationView(server_id)
+        view = NukeConfirmationView(server_id, interaction.user.id, interaction.user.display_name)
 
         # Send confirmation message with buttons
+        embed = discord.Embed(
+            title="Are you sure you want to nuke all playcounts?",
+            description="This will reset the played count for all games to zero, allowing the wheel to show all games equally. Play history will be preserved but ignored. Proceed with caution.",
+            color=discord.Color.red()
+        )
+        embed.add_field(name="Requested by", value=interaction.user.display_name, inline=True)
         await interaction.response.send_message(
-            embed=discord.Embed(
-                title="Are you sure you want to nuke all playcounts?",
-                description="This will reset the played count for all games to zero, allowing the wheel to show all games equally. Play history will be preserved but ignored. Proceed with caution.",
-                color=discord.Color.red()
-            ),
+            embed=embed,
             view=view,
             ephemeral=True
         )

--- a/db/database.py
+++ b/db/database.py
@@ -269,15 +269,15 @@ def nuke_playcounts(server_id: str) -> bool:
     if not games_list:
         return False
 
-    # Mark all GameLog entries for these games as ignored
-    any_logs_updated = False
-    for game in games_list:
-        if mark_game_logs_as_ignored(server_id, game.name):
-            any_logs_updated = True
-
-    # Reset playcount_offset to 0 for all games
     with get_session() as session:
+        game_ids = [game.id for game in games_list]
+
+        # Mark all GameLog entries for these games as ignored
+        updated_logs = session.query(GameLog).filter(GameLog.game_id.in_(game_ids)).update({"ignored": 1}, synchronize_session=False)
+
+        # Reset playcount_offset to 0 for all games
         updated_offsets = session.query(Game).filter(Game.server_id == server_id).update({"playcount_offset": 0}, synchronize_session=False)
+
         session.commit()
 
-    return any_logs_updated or updated_offsets > 0
+        return updated_logs > 0 or updated_offsets > 0


### PR DESCRIPTION
The new "nuke" command has been successfully implemented. Here's what was added:
1. Database Function: Added nuke_playcounts() in db/database.py that resets all played counts for a server by marking all GameLog entries as ignored and setting playcount_offset to 0.
2. Nuke Cog: Created cogs/nuke.py with a slash command /nuke that includes confirmation buttons to prevent accidental resets.
3. Automatic Loading: The bot automatically loads all cogs in the cogs/ directory, so the new command will be available when the bot restarts.
The command requires confirmation before proceeding, as it's a destructive action that affects all games in the server. Once executed, all games will have their played counts reset to zero, allowing the wheel to select from all games equally rather than favoring least-played ones. Play history is preserved but ignored for future selections.