### PR TITLE
Fix incorrect rotation being in losing slice

### DIFF
--- a/wheel_generator.py
+++ b/wheel_generator.py
@@ -159,7 +159,7 @@ def generate_wheel_of_games(games, winning_index, file_name):
     # + 1 so it's not stopping right on the line
     winning_max_rotation = 360 - ((winning_index * slice_size) + 1)
     # - 2 so it also doesn't stop right on the line
-    winning_min_rotation = winning_max_rotation - slice_size
+    winning_min_rotation = winning_max_rotation - (slice_size - 2)
 
     winning_rotation = int(random.uniform(winning_min_rotation, winning_max_rotation))
 


### PR DESCRIPTION
Fixes #8 

Fix the calculation of the minimum rotation for the winning slot.

Before Change
<img width="199" height="118" alt="image" src="https://github.com/user-attachments/assets/c31873fb-f1fb-4384-9d88-e303de9bb4c7" />

After change
<img width="183" height="117" alt="image" src="https://github.com/user-attachments/assets/c5573923-d080-41bc-b281-5120b6a5f0c6" />
