### PR TITLE
PR: Game Archive, Improved Removal & Search Filtering

### DIFF
--- a/cogs/archive_game.py
+++ b/cogs/archive_game.py
@@ -140,7 +140,7 @@ class ArchiveGameCommand(commands.Cog):
     async def autocomplete_active_games(self, interaction: Interaction, current: str):
         """Autocomplete from non-archived games only."""
         server_id = str(interaction.guild.id)
-        games = get_all_server_games(server_id)[:25]  # excludes archived
+        games = get_all_server_games(server_id, search=current)[:25]  # excludes archived
         return [
             discord.app_commands.Choice(name=game.name, value=game.name)
             for game in games if current.lower() in game.name.lower()
@@ -184,7 +184,7 @@ class ArchiveGameCommand(commands.Cog):
     async def autocomplete_archived_games(self, interaction: Interaction, current: str):
         """Autocomplete from archived games only."""
         server_id = str(interaction.guild.id)
-        games = get_archived_server_games(server_id)[:25]
+        games = get_archived_server_games(server_id, search=current)[:25]
         return [
             discord.app_commands.Choice(name=game.name, value=game.name)
             for game in games if current.lower() in game.name.lower()

--- a/cogs/archive_game.py
+++ b/cogs/archive_game.py
@@ -25,18 +25,15 @@ class ConfirmArchive(ui.View):
     async def confirm(self, interaction: Interaction, button: ui.Button):
         server_id = str(interaction.guild.id)
         success = archive_game_in_db(server_id, self.game_name)
+        await interaction.response.defer(ephemeral=True)
         if success:
-            await interaction.response.edit_message(
-                content=f"📦 **{self.game_name}** has been archived.",
-                embed=None,
-                view=None
-            )
-            await self.original_interaction.followup.send(
+            await self.original_interaction.delete_original_response()
+            await interaction.channel.send(
                 f"📦 **{self.game_name}** has been archived by {interaction.user.mention} "
                 f"and will no longer appear in searches or wheel spins."
             )
         else:
-            await interaction.response.edit_message(
+            await self.original_interaction.edit_original_response(
                 content="❌ This game no longer exists or was already removed.",
                 embed=None,
                 view=None
@@ -64,22 +61,20 @@ class ConfirmUnarchive(ui.View):
     async def confirm(self, interaction: Interaction, button: ui.Button):
         server_id = str(interaction.guild.id)
         success = unarchive_game_in_db(server_id, self.game_name)
+        await interaction.response.defer(ephemeral=True)
         if success:
-            await interaction.response.edit_message(
-                content=f"✅ **{self.game_name}** has been unarchived.",
-                embed=None,
-                view=None
-            )
-            await self.original_interaction.followup.send(
+            await self.original_interaction.delete_original_response()
+            await interaction.channel.send(
                 f"✅ **{self.game_name}** has been unarchived by {interaction.user.mention} "
                 f"and will appear in searches and wheel spins again."
             )
         else:
-            await interaction.response.edit_message(
+            await self.original_interaction.edit_original_response(
                 content="❌ This game no longer exists or was already removed.",
                 embed=None,
                 view=None
             )
+
 
     @ui.button(label="No, cancel", style=discord.ButtonStyle.secondary)
     async def cancel(self, interaction: Interaction, button: ui.Button):

--- a/cogs/archive_game.py
+++ b/cogs/archive_game.py
@@ -16,11 +16,10 @@ from db.database import (
 # ---------------------------------------------------------------------------
 
 class ConfirmArchive(ui.View):
-    def __init__(self, interaction: Interaction, game_name: str, banner_url: str):
-        super().__init__()
-        self.interaction = interaction
+    def __init__(self, interaction: Interaction, game_name: str):
+        super().__init__(timeout=300)
+        self.original_interaction = interaction
         self.game_name = game_name
-        self.banner_url = banner_url
 
     @ui.button(label="Yes, archive it", style=discord.ButtonStyle.primary)
     async def confirm(self, interaction: Interaction, button: ui.Button):
@@ -32,13 +31,13 @@ class ConfirmArchive(ui.View):
                 embed=None,
                 view=None
             )
-            await interaction.channel.send(
+            await self.original_interaction.followup.send(
                 f"📦 **{self.game_name}** has been archived by {interaction.user.mention} "
                 f"and will no longer appear in searches or wheel spins."
             )
         else:
             await interaction.response.edit_message(
-                content="❌ Error: No such game found.",
+                content="❌ This game no longer exists or was already removed.",
                 embed=None,
                 view=None
             )
@@ -51,17 +50,29 @@ class ConfirmArchive(ui.View):
             view=None
         )
 
+    async def on_timeout(self):
+        for child in self.children:
+            child.disabled = True
+        try:
+            embed = Embed(
+                title="⏱️ Archive Request Expired",
+                description=f"The request to archive **{self.game_name}** has expired. Run `/archivegame` again if still needed.",
+                color=discord.Color.dark_grey()
+            )
+            await self.original_interaction.edit_original_response(embed=embed, view=self)
+        except discord.NotFound:
+            pass
+
 
 # ---------------------------------------------------------------------------
 # Unarchive
 # ---------------------------------------------------------------------------
 
 class ConfirmUnarchive(ui.View):
-    def __init__(self, interaction: Interaction, game_name: str, banner_url: str):
-        super().__init__()
-        self.interaction = interaction
+    def __init__(self, interaction: Interaction, game_name: str):
+        super().__init__(timeout=300)
+        self.original_interaction = interaction
         self.game_name = game_name
-        self.banner_url = banner_url
 
     @ui.button(label="Yes, unarchive it", style=discord.ButtonStyle.success)
     async def confirm(self, interaction: Interaction, button: ui.Button):
@@ -73,13 +84,13 @@ class ConfirmUnarchive(ui.View):
                 embed=None,
                 view=None
             )
-            await interaction.channel.send(
+            await self.original_interaction.followup.send(
                 f"✅ **{self.game_name}** has been unarchived by {interaction.user.mention} "
                 f"and will appear in searches and wheel spins again."
             )
         else:
             await interaction.response.edit_message(
-                content="❌ Error: No such game found.",
+                content="❌ This game no longer exists or was already removed.",
                 embed=None,
                 view=None
             )
@@ -91,6 +102,19 @@ class ConfirmUnarchive(ui.View):
             embed=None,
             view=None
         )
+
+    async def on_timeout(self):
+        for child in self.children:
+            child.disabled = True
+        try:
+            embed = Embed(
+                title="⏱️ Unarchive Request Expired",
+                description=f"The request to unarchive **{self.game_name}** has expired. Run `/unarchivegame` again if still needed.",
+                color=discord.Color.dark_grey()
+            )
+            await self.original_interaction.edit_original_response(embed=embed, view=self)
+        except discord.NotFound:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -133,17 +157,17 @@ class ArchiveGameCommand(commands.Cog):
         if game.banner_link:
             embed.set_image(url=game.banner_link)
 
-        view = ConfirmArchive(interaction, game.name, game.banner_link)
+        view = ConfirmArchive(interaction, game.name)
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
 
     @archive_game.autocomplete("name")
     async def autocomplete_active_games(self, interaction: Interaction, current: str):
         """Autocomplete from non-archived games only."""
         server_id = str(interaction.guild.id)
-        games = get_all_server_games(server_id, search=current)[:25]  # excludes archived
+        games = get_all_server_games(server_id, search=current)[:25]
         return [
             discord.app_commands.Choice(name=game.name, value=game.name)
-            for game in games if current.lower() in game.name.lower()
+            for game in games
         ]
 
     # --- /unarchivegame ---
@@ -177,7 +201,7 @@ class ArchiveGameCommand(commands.Cog):
         if game.banner_link:
             embed.set_image(url=game.banner_link)
 
-        view = ConfirmUnarchive(interaction, game.name, game.banner_link)
+        view = ConfirmUnarchive(interaction, game.name)
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
 
     @unarchive_game.autocomplete("name")
@@ -187,7 +211,7 @@ class ArchiveGameCommand(commands.Cog):
         games = get_archived_server_games(server_id, search=current)[:25]
         return [
             discord.app_commands.Choice(name=game.name, value=game.name)
-            for game in games if current.lower() in game.name.lower()
+            for game in games
         ]
 
 

--- a/cogs/archive_game.py
+++ b/cogs/archive_game.py
@@ -1,0 +1,196 @@
+import discord
+from discord import Interaction, ui, Embed
+from discord.ext import commands
+
+from db.database import (
+    archive_game_in_db,
+    unarchive_game_in_db,
+    fetch_game_from_db,
+    get_all_server_games,
+    get_archived_server_games,
+)
+
+
+# ---------------------------------------------------------------------------
+# Archive
+# ---------------------------------------------------------------------------
+
+class ConfirmArchive(ui.View):
+    def __init__(self, interaction: Interaction, game_name: str, banner_url: str):
+        super().__init__()
+        self.interaction = interaction
+        self.game_name = game_name
+        self.banner_url = banner_url
+
+    @ui.button(label="Yes, archive it", style=discord.ButtonStyle.primary)
+    async def confirm(self, interaction: Interaction, button: ui.Button):
+        server_id = str(interaction.guild.id)
+        success = archive_game_in_db(server_id, self.game_name)
+        if success:
+            await interaction.response.edit_message(
+                content=f"📦 **{self.game_name}** has been archived.",
+                embed=None,
+                view=None
+            )
+            await interaction.channel.send(
+                f"📦 **{self.game_name}** has been archived by {interaction.user.mention} "
+                f"and will no longer appear in searches or wheel spins."
+            )
+        else:
+            await interaction.response.edit_message(
+                content="❌ Error: No such game found.",
+                embed=None,
+                view=None
+            )
+
+    @ui.button(label="No, cancel", style=discord.ButtonStyle.secondary)
+    async def cancel(self, interaction: Interaction, button: ui.Button):
+        await interaction.response.edit_message(
+            content="Archive cancelled. No changes were made.",
+            embed=None,
+            view=None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unarchive
+# ---------------------------------------------------------------------------
+
+class ConfirmUnarchive(ui.View):
+    def __init__(self, interaction: Interaction, game_name: str, banner_url: str):
+        super().__init__()
+        self.interaction = interaction
+        self.game_name = game_name
+        self.banner_url = banner_url
+
+    @ui.button(label="Yes, unarchive it", style=discord.ButtonStyle.success)
+    async def confirm(self, interaction: Interaction, button: ui.Button):
+        server_id = str(interaction.guild.id)
+        success = unarchive_game_in_db(server_id, self.game_name)
+        if success:
+            await interaction.response.edit_message(
+                content=f"✅ **{self.game_name}** has been unarchived.",
+                embed=None,
+                view=None
+            )
+            await interaction.channel.send(
+                f"✅ **{self.game_name}** has been unarchived by {interaction.user.mention} "
+                f"and will appear in searches and wheel spins again."
+            )
+        else:
+            await interaction.response.edit_message(
+                content="❌ Error: No such game found.",
+                embed=None,
+                view=None
+            )
+
+    @ui.button(label="No, cancel", style=discord.ButtonStyle.secondary)
+    async def cancel(self, interaction: Interaction, button: ui.Button):
+        await interaction.response.edit_message(
+            content="Unarchive cancelled. No changes were made.",
+            embed=None,
+            view=None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cog
+# ---------------------------------------------------------------------------
+
+class ArchiveGameCommand(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    # --- /archivegame ---
+
+    @discord.app_commands.command(
+        name="archivegame",
+        description="Archive a game so it won't appear in searches or wheel spins (but isn't deleted)."
+    )
+    async def archive_game(self, interaction: Interaction, name: str):
+        server_id = str(interaction.guild.id)
+
+        game = fetch_game_from_db(server_id, name)
+        if game is None:
+            await interaction.response.send_message("❌ Error: No such game found.", ephemeral=True)
+            return
+
+        if game.archived:
+            await interaction.response.send_message(
+                f"**{game.name}** is already archived. Use `/unarchivegame` to restore it.",
+                ephemeral=True
+            )
+            return
+
+        embed = Embed(
+            title="📦 Archive Game?",
+            description=(
+                f"Archiving **{game.name}** will hide it from searches and wheel spins.\n\n"
+                "Its play history will be preserved and you can restore it at any time with `/unarchivegame`."
+            ),
+            color=discord.Color.blurple()
+        )
+        if game.banner_link:
+            embed.set_image(url=game.banner_link)
+
+        view = ConfirmArchive(interaction, game.name, game.banner_link)
+        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
+    @archive_game.autocomplete("name")
+    async def autocomplete_active_games(self, interaction: Interaction, current: str):
+        """Autocomplete from non-archived games only."""
+        server_id = str(interaction.guild.id)
+        games = get_all_server_games(server_id)[:25]  # excludes archived
+        return [
+            discord.app_commands.Choice(name=game.name, value=game.name)
+            for game in games if current.lower() in game.name.lower()
+        ]
+
+    # --- /unarchivegame ---
+
+    @discord.app_commands.command(
+        name="unarchivegame",
+        description="Restore an archived game so it appears in searches and wheel spins again."
+    )
+    async def unarchive_game(self, interaction: Interaction, name: str):
+        server_id = str(interaction.guild.id)
+
+        game = fetch_game_from_db(server_id, name)
+        if game is None:
+            await interaction.response.send_message("❌ Error: No such game found.", ephemeral=True)
+            return
+
+        if not game.archived:
+            await interaction.response.send_message(
+                f"**{game.name}** is not archived. Use `/archivegame` to archive it.",
+                ephemeral=True
+            )
+            return
+
+        embed = Embed(
+            title="✅ Unarchive Game?",
+            description=(
+                f"Restoring **{game.name}** will make it visible in searches and wheel spins again."
+            ),
+            color=discord.Color.green()
+        )
+        if game.banner_link:
+            embed.set_image(url=game.banner_link)
+
+        view = ConfirmUnarchive(interaction, game.name, game.banner_link)
+        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
+    @unarchive_game.autocomplete("name")
+    async def autocomplete_archived_games(self, interaction: Interaction, current: str):
+        """Autocomplete from archived games only."""
+        server_id = str(interaction.guild.id)
+        games = get_archived_server_games(server_id)[:25]
+        return [
+            discord.app_commands.Choice(name=game.name, value=game.name)
+            for game in games if current.lower() in game.name.lower()
+        ]
+
+
+# Setup function to add the cog to the bot
+async def setup(bot):
+    await bot.add_cog(ArchiveGameCommand(bot))

--- a/cogs/archive_game.py
+++ b/cogs/archive_game.py
@@ -17,7 +17,7 @@ from db.database import (
 
 class ConfirmArchive(ui.View):
     def __init__(self, interaction: Interaction, game_name: str):
-        super().__init__(timeout=300)
+        super().__init__()
         self.original_interaction = interaction
         self.game_name = game_name
 
@@ -50,27 +50,13 @@ class ConfirmArchive(ui.View):
             view=None
         )
 
-    async def on_timeout(self):
-        for child in self.children:
-            child.disabled = True
-        try:
-            embed = Embed(
-                title="⏱️ Archive Request Expired",
-                description=f"The request to archive **{self.game_name}** has expired. Run `/archivegame` again if still needed.",
-                color=discord.Color.dark_grey()
-            )
-            await self.original_interaction.edit_original_response(embed=embed, view=self)
-        except discord.NotFound:
-            pass
-
-
 # ---------------------------------------------------------------------------
 # Unarchive
 # ---------------------------------------------------------------------------
 
 class ConfirmUnarchive(ui.View):
     def __init__(self, interaction: Interaction, game_name: str):
-        super().__init__(timeout=300)
+        super().__init__()
         self.original_interaction = interaction
         self.game_name = game_name
 
@@ -102,19 +88,6 @@ class ConfirmUnarchive(ui.View):
             embed=None,
             view=None
         )
-
-    async def on_timeout(self):
-        for child in self.children:
-            child.disabled = True
-        try:
-            embed = Embed(
-                title="⏱️ Unarchive Request Expired",
-                description=f"The request to unarchive **{self.game_name}** has expired. Run `/unarchivegame` again if still needed.",
-                color=discord.Color.dark_grey()
-            )
-            await self.original_interaction.edit_original_response(embed=embed, view=self)
-        except discord.NotFound:
-            pass
 
 
 # ---------------------------------------------------------------------------

--- a/cogs/choose_game.py
+++ b/cogs/choose_game.py
@@ -40,9 +40,9 @@ def create_game_embed(game: GameWithPlayHistory):
 
 
 # Function to choose a game randomly
-def pick_game(games: List[GameWithPlayHistory], exclude_game_id: str = None, ignore_choosing_least_played=False) -> \
+def pick_game(games: List[GameWithPlayHistory], exclude_game_id: str = None, ignore_least_played_bias=False) -> \
         tuple[List[GameWithPlayHistory], GameWithPlayHistory]:
-    if not ignore_choosing_least_played:
+    if not ignore_least_played_bias:
         # Filter games to include only those with the least  number of times played
         min_play_count = min(
             len(game.play_history) + game.playcount_offset for game in games)  # Find the minimum play count
@@ -66,7 +66,7 @@ def pick_game(games: List[GameWithPlayHistory], exclude_game_id: str = None, ign
 
 class ConfirmChoice(ui.View):
     def __init__(self, interaction, bot, initial_game, all_games, gif_message, player_count, server_id, event_day=None):
-        super().__init__()
+        super().__init__(timeout=300)
         self.interaction = interaction
         self.bot = bot
         self.current_game = initial_game
@@ -92,7 +92,7 @@ class ConfirmChoice(ui.View):
 
         # Pick a game
         game_options, chosen_game = pick_game(games, exclude_game_id=exclude_game_id,
-                                              ignore_choosing_least_played=ignore_least_played)
+                                              ignore_least_played_bias=ignore_least_played)
         if not chosen_game:
             await interaction.followup.send("No games available to choose from.", ephemeral=True)
             return None
@@ -213,7 +213,7 @@ class ChooseGameCommand(commands.Cog):
             return
 
         # Pick a game
-        game_options, chosen_game = pick_game(games, ignore_choosing_least_played=ignore_least_played)
+        game_options, chosen_game = pick_game(games, ignore_least_played_bias=ignore_least_played)
 
         if force_game:
             matching_game = fetch_game_with_memory(server_id, force_game)
@@ -281,9 +281,25 @@ class ChooseGameCommand(commands.Cog):
 
         return [
             discord.app_commands.Choice(name=game.name, value=game.name)
-            for game in game_names if current.lower() in game.name.lower()
+            for game in game_names
         ]
 
+
+
+    async def on_timeout(self):
+        for child in self.children:
+            child.disabled = True
+        try:
+            embed = Embed(
+                title="⏱️ Game Selection Expired",
+                description=f"The selection for **{self.current_game.name}** has expired. Run `/choosegame` again to spin the wheel.",
+                color=discord.Color.dark_grey()
+            )
+            embed.add_field(name="Players", value=str(self.player_count), inline=True)
+            await self.gif_message.delete()
+            await self.interaction.edit_original_response(embed=embed, view=self)
+        except (discord.NotFound, Exception):
+            pass
 
 async def setup(bot):
     await bot.add_cog(ChooseGameCommand(bot))

--- a/cogs/choose_game.py
+++ b/cogs/choose_game.py
@@ -66,7 +66,7 @@ def pick_game(games: List[GameWithPlayHistory], exclude_game_id: str = None, ign
 
 class ConfirmChoice(ui.View):
     def __init__(self, interaction, bot, initial_game, all_games, gif_message, player_count, server_id, event_day=None):
-        super().__init__(timeout=300)
+        super().__init__()
         self.interaction = interaction
         self.bot = bot
         self.current_game = initial_game
@@ -284,22 +284,6 @@ class ChooseGameCommand(commands.Cog):
             for game in game_names
         ]
 
-
-
-    async def on_timeout(self):
-        for child in self.children:
-            child.disabled = True
-        try:
-            embed = Embed(
-                title="⏱️ Game Selection Expired",
-                description=f"The selection for **{self.current_game.name}** has expired. Run `/choosegame` again to spin the wheel.",
-                color=discord.Color.dark_grey()
-            )
-            embed.add_field(name="Players", value=str(self.player_count), inline=True)
-            await self.gif_message.delete()
-            await self.interaction.edit_original_response(embed=embed, view=self)
-        except (discord.NotFound, Exception):
-            pass
 
 async def setup(bot):
     await bot.add_cog(ChooseGameCommand(bot))

--- a/cogs/choose_game.py
+++ b/cogs/choose_game.py
@@ -204,12 +204,16 @@ class ChooseGameCommand(commands.Cog):
         if not ignore_least_played:
             games = get_least_played_games(server_id, player_count)
 
+        if len(games) > 25:
+            logger.info(f"Reducing games to 25, currently it is {len(games)}")
+            games = random.sample(games, 25)
+
         if not games:
             await interaction.response.send_message(f"No games support {player_count} players!", ephemeral=True)
             return
 
         # Pick a game
-        game_options, chosen_game = pick_game(games)
+        game_options, chosen_game = pick_game(games, ignore_choosing_least_played=ignore_least_played)
 
         if force_game:
             matching_game = fetch_game_with_memory(server_id, force_game)

--- a/cogs/choose_game.py
+++ b/cogs/choose_game.py
@@ -277,7 +277,7 @@ class ChooseGameCommand(commands.Cog):
     async def autocomplete_force_game(self, interaction: Interaction, current: str):
         """Provide autocomplete suggestions for game names."""
         server_id = str(interaction.guild.id)
-        game_names = get_all_server_games(server_id)  # Fetch a list of game names from the database
+        game_names = get_all_server_games(server_id, search=current)[:25]  # Fetch a list of game names from the database
 
         return [
             discord.app_commands.Choice(name=game.name, value=game.name)

--- a/cogs/remove_game.py
+++ b/cogs/remove_game.py
@@ -6,27 +6,34 @@ from db.database import remove_game_from_db, fetch_game_from_db, get_all_server_
 
 
 class ConfirmRemove(ui.View):
-    def __init__(self, interaction: Interaction, game_name: str, banner_url: str):
+    def __init__(self, requester_id: int, requester_name: str, game_name: str, banner_url: str):
         super().__init__()
-        self.interaction = interaction
+        self.requester_id = requester_id
+        self.requester_name = requester_name
         self.game_name = game_name
         self.banner_url = banner_url
 
     @ui.button(label="⚠️ Yes, permanently delete", style=discord.ButtonStyle.danger)
     async def confirm(self, interaction: Interaction, button: ui.Button):
+        if interaction.user.id == self.requester_id:
+            await interaction.response.send_message(
+                "You cannot approve your own removal request.", ephemeral=True
+            )
+            return
+
         server_id = str(interaction.guild.id)
         successful_removal = remove_game_from_db(server_id, self.game_name)
         if successful_removal:
-            # Update the private confirmation message
-            await interaction.response.edit_message(
-                content=f"✅ **{self.game_name}** has been permanently deleted.",
-                embed=None,
-                view=None
+            embed = Embed(
+                title="🗑️ Game Permanently Deleted",
+                description=f"**{self.game_name}** has been permanently removed from the game list.",
+                color=discord.Color.red()
             )
-            # Send a public message so the channel knows
-            await interaction.channel.send(
-                f"🗑️ **{self.game_name}** has been permanently removed from the game list by {interaction.user.mention}."
-            )
+            embed.add_field(name="Requested by", value=self.requester_name, inline=True)
+            embed.add_field(name="Approved by", value=interaction.user.display_name, inline=True)
+            if self.banner_url:
+                embed.set_image(url=self.banner_url)
+            await interaction.response.edit_message(embed=embed, view=None)
         else:
             await interaction.response.edit_message(
                 content="❌ Error: No such game found.",
@@ -63,18 +70,20 @@ class RemoveGameCommand(commands.Cog):
         embed = Embed(
             title="⚠️ Permanently Delete Game?",
             description=(
-                f"You are about to **permanently delete** **{game_name}** from the game list.\n\n"
+                f"**{interaction.user.display_name}** wants to **permanently delete** **{game_name}** from the game list.\n\n"
                 "This will remove the game and **all of its play history** forever. "
                 "This action **cannot be undone**.\n\n"
-                "If you just want to hide the game from searches and the wheel, use `/archivegame` instead."
+                "If you just want to hide the game from searches and the wheel, use `/archivegame` instead.\n\n"
+                "**This request must be approved by another server member.**"
             ),
             color=discord.Color.red()
         )
+        embed.add_field(name="Requested by", value=interaction.user.display_name, inline=True)
         if banner_url:
             embed.set_image(url=banner_url)
 
-        view = ConfirmRemove(interaction, game_name, banner_url)
-        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+        view = ConfirmRemove(interaction.user.id, interaction.user.display_name, game_name, banner_url)
+        await interaction.response.send_message(embed=embed, view=view)
 
     @remove_game.autocomplete("name")
     async def autocomplete_games(self, interaction: Interaction, current: str):

--- a/cogs/remove_game.py
+++ b/cogs/remove_game.py
@@ -7,7 +7,7 @@ from db.database import remove_game_from_db, fetch_game_from_db, get_all_server_
 
 class ConfirmRemove(ui.View):
     def __init__(self, requester_id: int, requester_name: str, game_name: str, banner_url: str):
-        super().__init__(timeout=10)
+        super().__init__()
         self.requester_id = requester_id
         self.requester_name = requester_name
         self.game_name = game_name
@@ -48,20 +48,6 @@ class ConfirmRemove(ui.View):
             embed=None,
             view=None
         )
-
-    async def on_timeout(self):
-        for child in self.children:
-            child.disabled = True
-        try:
-            embed = Embed(
-                title="⏱️ Deletion Request Expired",
-                description=f"The request to permanently delete **{self.game_name}** has expired. Run `/removegame` again if still needed.",
-                color=discord.Color.dark_grey()
-            )
-            embed.add_field(name="Requested by", value=self.requester_name, inline=True)
-            await self.message.edit(embed=embed, view=self)
-        except discord.NotFound:
-            pass
 
 
 class RemoveGameCommand(commands.Cog):

--- a/cogs/remove_game.py
+++ b/cogs/remove_game.py
@@ -7,7 +7,7 @@ from db.database import remove_game_from_db, fetch_game_from_db, get_all_server_
 
 class ConfirmRemove(ui.View):
     def __init__(self, requester_id: int, requester_name: str, game_name: str, banner_url: str):
-        super().__init__()
+        super().__init__(timeout=10)
         self.requester_id = requester_id
         self.requester_name = requester_name
         self.game_name = game_name
@@ -36,7 +36,7 @@ class ConfirmRemove(ui.View):
             await interaction.response.edit_message(embed=embed, view=None)
         else:
             await interaction.response.edit_message(
-                content="❌ Error: No such game found.",
+                content="❌ This game no longer exists or was already removed.",
                 embed=None,
                 view=None
             )
@@ -48,6 +48,20 @@ class ConfirmRemove(ui.View):
             embed=None,
             view=None
         )
+
+    async def on_timeout(self):
+        for child in self.children:
+            child.disabled = True
+        try:
+            embed = Embed(
+                title="⏱️ Deletion Request Expired",
+                description=f"The request to permanently delete **{self.game_name}** has expired. Run `/removegame` again if still needed.",
+                color=discord.Color.dark_grey()
+            )
+            embed.add_field(name="Requested by", value=self.requester_name, inline=True)
+            await self.message.edit(embed=embed, view=self)
+        except discord.NotFound:
+            pass
 
 
 class RemoveGameCommand(commands.Cog):
@@ -66,7 +80,6 @@ class RemoveGameCommand(commands.Cog):
         game_name = game.name
         banner_url = game.banner_link
 
-        # Make the destructive nature very clear in the confirmation embed
         embed = Embed(
             title="⚠️ Permanently Delete Game?",
             description=(
@@ -84,16 +97,16 @@ class RemoveGameCommand(commands.Cog):
 
         view = ConfirmRemove(interaction.user.id, interaction.user.display_name, game_name, banner_url)
         await interaction.response.send_message(embed=embed, view=view)
+        view.message = await interaction.original_response()
 
     @remove_game.autocomplete("name")
     async def autocomplete_games(self, interaction: Interaction, current: str):
         """Provide autocomplete suggestions for game names (includes archived games)."""
         server_id = str(interaction.guild.id)
-        game_names = get_all_server_games_including_archived(server_id, search=current)[:25]
-
+        games = get_all_server_games_including_archived(server_id, search=current)[:25]
         return [
             discord.app_commands.Choice(name=game.name, value=game.name)
-            for game in game_names if current.lower() in game.name.lower()
+            for game in games
         ]
 
 

--- a/cogs/remove_game.py
+++ b/cogs/remove_game.py
@@ -83,7 +83,6 @@ class RemoveGameCommand(commands.Cog):
 
         view = ConfirmRemove(interaction.user.id, interaction.user.display_name, game_name, banner_url)
         await interaction.response.send_message(embed=embed, view=view)
-        view.message = await interaction.original_response()
 
     @remove_game.autocomplete("name")
     async def autocomplete_games(self, interaction: Interaction, current: str):

--- a/cogs/remove_game.py
+++ b/cogs/remove_game.py
@@ -2,7 +2,7 @@ import discord
 from discord import Interaction, ui, Embed
 from discord.ext import commands
 
-from db.database import remove_game_from_db, fetch_game_from_db, get_all_server_games
+from db.database import remove_game_from_db, fetch_game_from_db, get_all_server_games_including_archived
 
 
 class ConfirmRemove(ui.View):
@@ -12,19 +12,24 @@ class ConfirmRemove(ui.View):
         self.game_name = game_name
         self.banner_url = banner_url
 
-    @ui.button(label="Yes, remove", style=discord.ButtonStyle.danger)
+    @ui.button(label="⚠️ Yes, permanently delete", style=discord.ButtonStyle.danger)
     async def confirm(self, interaction: Interaction, button: ui.Button):
         server_id = str(interaction.guild.id)
         successful_removal = remove_game_from_db(server_id, self.game_name)
         if successful_removal:
+            # Update the private confirmation message
             await interaction.response.edit_message(
-                content=f"'{self.game_name}' has been successfully removed.",
+                content=f"✅ **{self.game_name}** has been permanently deleted.",
                 embed=None,
                 view=None
             )
+            # Send a public message so the channel knows
+            await interaction.channel.send(
+                f"🗑️ **{self.game_name}** has been permanently removed from the game list by {interaction.user.mention}."
+            )
         else:
             await interaction.response.edit_message(
-                content="Error: No such game found.",
+                content="❌ Error: No such game found.",
                 embed=None,
                 view=None
             )
@@ -32,7 +37,7 @@ class ConfirmRemove(ui.View):
     @ui.button(label="No, cancel", style=discord.ButtonStyle.secondary)
     async def cancel(self, interaction: Interaction, button: ui.Button):
         await interaction.response.edit_message(
-            content="Game removal canceled.",
+            content="Game removal cancelled. No changes were made.",
             embed=None,
             view=None
         )
@@ -42,33 +47,40 @@ class RemoveGameCommand(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @discord.app_commands.command(name="removegame", description="Remove a game from the list.")
+    @discord.app_commands.command(name="removegame", description="Permanently delete a game from the list.")
     async def remove_game(self, interaction: Interaction, name: str):
         server_id = str(interaction.guild.id)
 
-        # Fetch game details from the database (replace this with your actual query)
         game = fetch_game_from_db(server_id, name)
         if game is None:
-            await interaction.response.send_message("Error: No such game found.", ephemeral=True)
+            await interaction.response.send_message("❌ Error: No such game found.", ephemeral=True)
             return
 
         game_name = game.name
         banner_url = game.banner_link
 
-        # Create an embed for confirmation
-        embed = Embed(title="Confirm Game Removal", description=f"Are you sure you want to remove **{game_name}**?")
+        # Make the destructive nature very clear in the confirmation embed
+        embed = Embed(
+            title="⚠️ Permanently Delete Game?",
+            description=(
+                f"You are about to **permanently delete** **{game_name}** from the game list.\n\n"
+                "This will remove the game and **all of its play history** forever. "
+                "This action **cannot be undone**.\n\n"
+                "If you just want to hide the game from searches and the wheel, use `/archivegame` instead."
+            ),
+            color=discord.Color.red()
+        )
         if banner_url:
             embed.set_image(url=banner_url)
 
-        # Send the embed with confirmation buttons
         view = ConfirmRemove(interaction, game_name, banner_url)
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
 
     @remove_game.autocomplete("name")
     async def autocomplete_games(self, interaction: Interaction, current: str):
-        """Provide autocomplete suggestions for game names."""
+        """Provide autocomplete suggestions for game names (includes archived games)."""
         server_id = str(interaction.guild.id)
-        game_names = get_all_server_games(server_id)  # Fetch a list of game names from the database
+        game_names = get_all_server_games_including_archived(server_id)[:25]
 
         return [
             discord.app_commands.Choice(name=game.name, value=game.name)

--- a/cogs/remove_game.py
+++ b/cogs/remove_game.py
@@ -89,7 +89,7 @@ class RemoveGameCommand(commands.Cog):
     async def autocomplete_games(self, interaction: Interaction, current: str):
         """Provide autocomplete suggestions for game names (includes archived games)."""
         server_id = str(interaction.guild.id)
-        game_names = get_all_server_games_including_archived(server_id)[:25]
+        game_names = get_all_server_games_including_archived(server_id, search=current)[:25]
 
         return [
             discord.app_commands.Choice(name=game.name, value=game.name)

--- a/db/database.py
+++ b/db/database.py
@@ -133,6 +133,9 @@ def fetch_game_with_memory(server_id: str, name: str) -> Optional[GameWithPlayHi
 
 def _build_game_with_play_history(games, session) -> List[GameWithPlayHistory]:
     """Helper: given a list of Game ORM objects, attach play history and return dataclasses."""
+    if not games:
+        return []
+
     game_ids = [game.id for game in games]
 
     logs = (
@@ -175,7 +178,7 @@ def get_all_server_games(server_id: str, search: Optional[str] = None) -> List[G
         query = (
             session.query(Game)
             .filter(Game.server_id == server_id)
-            .filter(Game.archived == False)  # noqa: E712
+            .filter(Game.archived.is_(False))
         )
         if search:
             query = query.filter(Game.name.ilike(f"%{search}%"))
@@ -193,7 +196,7 @@ def get_archived_server_games(server_id: str, search: Optional[str] = None) -> L
         query = (
             session.query(Game)
             .filter(Game.server_id == server_id)
-            .filter(Game.archived == True)  # noqa: E712
+            .filter(Game.archived.is_(True))
         )
         if search:
             query = query.filter(Game.name.ilike(f"%{search}%"))

--- a/db/database.py
+++ b/db/database.py
@@ -164,39 +164,57 @@ def _build_game_with_play_history(games, session) -> List[GameWithPlayHistory]:
     ]
 
 
-def get_all_server_games(server_id: str) -> List[GameWithPlayHistory]:
-    """Retrieve all non-archived games for a server, including play history."""
+def get_all_server_games(server_id: str, search: Optional[str] = None) -> List[GameWithPlayHistory]:
+    """Retrieve all non-archived games for a server, including play history.
+
+    Args:
+        search: Optional partial name filter (case-insensitive). Only games whose
+                name contains this string will be returned.
+    """
     with get_session() as session:
-        games = (
+        query = (
             session.query(Game)
             .filter(Game.server_id == server_id)
             .filter(Game.archived == False)  # noqa: E712
-            .all()
         )
-        return _build_game_with_play_history(games, session)
+        if search:
+            query = query.filter(Game.name.ilike(f"%{search}%"))
+        return _build_game_with_play_history(query.all(), session)
 
 
-def get_archived_server_games(server_id: str) -> List[GameWithPlayHistory]:
-    """Retrieve all archived games for a server."""
+def get_archived_server_games(server_id: str, search: Optional[str] = None) -> List[GameWithPlayHistory]:
+    """Retrieve all archived games for a server.
+
+    Args:
+        search: Optional partial name filter (case-insensitive). Only games whose
+                name contains this string will be returned.
+    """
     with get_session() as session:
-        games = (
+        query = (
             session.query(Game)
             .filter(Game.server_id == server_id)
             .filter(Game.archived == True)  # noqa: E712
-            .all()
         )
-        return _build_game_with_play_history(games, session)
+        if search:
+            query = query.filter(Game.name.ilike(f"%{search}%"))
+        return _build_game_with_play_history(query.all(), session)
 
 
-def get_all_server_games_including_archived(server_id: str) -> List[GameWithPlayHistory]:
-    """Retrieve every game for a server regardless of archived status (e.g. for /removegame autocomplete)."""
+def get_all_server_games_including_archived(server_id: str, search: Optional[str] = None) -> List[GameWithPlayHistory]:
+    """Retrieve every game for a server regardless of archived status (e.g. for /removegame autocomplete).
+
+    Args:
+        search: Optional partial name filter (case-insensitive). Only games whose
+                name contains this string will be returned.
+    """
     with get_session() as session:
-        games = (
+        query = (
             session.query(Game)
             .filter(Game.server_id == server_id)
-            .all()
         )
-        return _build_game_with_play_history(games, session)
+        if search:
+            query = query.filter(Game.name.ilike(f"%{search}%"))
+        return _build_game_with_play_history(query.all(), session)
 
 
 def get_eligible_games(server_id: str, player_count: int) -> list[GameWithPlayHistory]:

--- a/db/database.py
+++ b/db/database.py
@@ -62,6 +62,28 @@ def remove_game_from_db(server_id: str, name: str) -> bool:
         return False
 
 
+def archive_game_in_db(server_id: str, name: str) -> bool:
+    """Mark a game as archived. Returns True if the game was found and updated."""
+    with get_session() as session:
+        game = session.query(Game).filter_by(server_id=server_id, name=name).first()
+        if not game:
+            return False
+        game.archived = True
+        session.commit()
+        return True
+
+
+def unarchive_game_in_db(server_id: str, name: str) -> bool:
+    """Remove the archived flag from a game. Returns True if the game was found and updated."""
+    with get_session() as session:
+        game = session.query(Game).filter_by(server_id=server_id, name=name).first()
+        if not game:
+            return False
+        game.archived = False
+        session.commit()
+        return True
+
+
 def fetch_game_from_db(server_id: str, name: str) -> Optional[Game]:
     """Fetch the full Game object by server ID and name"""
     with get_session() as session:
@@ -104,55 +126,81 @@ def fetch_game_with_memory(server_id: str, name: str) -> Optional[GameWithPlayHi
             steam_link=game.steam_link,
             banner_link=game.banner_link,
             playcount_offset=game.playcount_offset,
-            play_history=play_history
+            play_history=play_history,
+            archived=game.archived,
         )
 
 
+def _build_game_with_play_history(games, session) -> List[GameWithPlayHistory]:
+    """Helper: given a list of Game ORM objects, attach play history and return dataclasses."""
+    game_ids = [game.id for game in games]
+
+    logs = (
+        session.query(GameLog.game_id, GameLog.chosen_at)
+        .filter(GameLog.game_id.in_(game_ids))
+        .filter((GameLog.ignored.is_(None)) | (GameLog.ignored == 0))
+        .order_by(GameLog.chosen_at.desc())
+        .all()
+    )
+
+    history_map: dict[int, List[datetime]] = {}
+    for game_id, timestamp in logs:
+        history_map.setdefault(game_id, []).append(timestamp)
+
+    return [
+        GameWithPlayHistory(
+            id=game.id,
+            server_id=game.server_id,
+            name=game.name,
+            min_players=game.min_players,
+            max_players=game.max_players,
+            steam_link=game.steam_link,
+            banner_link=game.banner_link,
+            playcount_offset=game.playcount_offset,
+            play_history=history_map.get(game.id, []),
+            archived=game.archived,
+        )
+        for game in games
+    ]
+
+
 def get_all_server_games(server_id: str) -> List[GameWithPlayHistory]:
-    """Retrieve all games for a server, including play history as a list of datetimes."""
+    """Retrieve all non-archived games for a server, including play history."""
+    with get_session() as session:
+        games = (
+            session.query(Game)
+            .filter(Game.server_id == server_id)
+            .filter(Game.archived == False)  # noqa: E712
+            .all()
+        )
+        return _build_game_with_play_history(games, session)
+
+
+def get_archived_server_games(server_id: str) -> List[GameWithPlayHistory]:
+    """Retrieve all archived games for a server."""
+    with get_session() as session:
+        games = (
+            session.query(Game)
+            .filter(Game.server_id == server_id)
+            .filter(Game.archived == True)  # noqa: E712
+            .all()
+        )
+        return _build_game_with_play_history(games, session)
+
+
+def get_all_server_games_including_archived(server_id: str) -> List[GameWithPlayHistory]:
+    """Retrieve every game for a server regardless of archived status (e.g. for /removegame autocomplete)."""
     with get_session() as session:
         games = (
             session.query(Game)
             .filter(Game.server_id == server_id)
             .all()
         )
-
-        game_ids = [game.id for game in games]
-
-        # Fetch play history for all games at once
-        logs = (
-            session.query(GameLog.game_id, GameLog.chosen_at)
-            .filter(GameLog.game_id.in_(game_ids))
-            .filter((GameLog.ignored.is_(None)) | (GameLog.ignored == 0))
-            .order_by(GameLog.chosen_at.desc())
-            .all()
-        )
-
-        # Organize logs by game_id
-        history_map: dict[int, List[datetime]] = {}
-        for game_id, timestamp in logs:
-            history_map.setdefault(game_id, []).append(timestamp)
-
-        # Build result
-        result = []
-        for game in games:
-            result.append(GameWithPlayHistory(
-                id=game.id,
-                server_id=game.server_id,
-                name=game.name,
-                min_players=game.min_players,
-                max_players=game.max_players,
-                steam_link=game.steam_link,
-                banner_link=game.banner_link,
-                playcount_offset=game.playcount_offset,
-                play_history=history_map.get(game.id, [])
-            ))
-
-        return result
+        return _build_game_with_play_history(games, session)
 
 
 def get_eligible_games(server_id: str, player_count: int) -> list[GameWithPlayHistory]:
-    """Retrieve games that match the player count by filtering existing server games."""
+    """Retrieve non-archived games that match the player count."""
     all_games = get_all_server_games(server_id)
     return [
         game for game in all_games
@@ -161,7 +209,7 @@ def get_eligible_games(server_id: str, player_count: int) -> list[GameWithPlayHi
 
 
 def get_least_played_games(server_id: str, player_count: int) -> list[GameWithPlayHistory]:
-    """Retrieve the least played games that match the player count."""
+    """Retrieve the least played non-archived games that match the player count."""
     all_games = get_all_server_games(server_id)
     eligible_games = [
         game for game in all_games
@@ -264,8 +312,8 @@ def nuke_playcounts(server_id: str) -> bool:
 
     Returns True if any changes were made.
     """
-    # Get all games for the server
-    games_list = get_all_server_games(server_id)
+    # Get all games for the server (including archived — play history still valid)
+    games_list = get_all_server_games_including_archived(server_id)
     if not games_list:
         return False
 

--- a/db/migrations/002_add_archived.py
+++ b/db/migrations/002_add_archived.py
@@ -1,0 +1,28 @@
+"""
+Migration: Add `archived` column to game_list.
+
+Existing rows default to 0 (not archived).
+This migration is idempotent — safe to run multiple times.
+"""
+
+import sqlite3
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def run_migration(conn: sqlite3.Connection):
+    cursor = conn.cursor()
+
+    # Check whether the column already exists
+    cursor.execute("PRAGMA table_info(game_list)")
+    columns = [row[1] for row in cursor.fetchall()]
+
+    if "archived" not in columns:
+        logger.info("Migration: adding 'archived' column to game_list")
+        cursor.execute(
+            "ALTER TABLE game_list ADD COLUMN archived INTEGER NOT NULL DEFAULT 0"
+        )
+        conn.commit()
+    else:
+        logger.debug("Migration skipped: 'archived' column already present")

--- a/db/models.py
+++ b/db/models.py
@@ -19,6 +19,7 @@ class GameWithPlayHistory:
     banner_link: Optional[str]
     playcount_offset: int
     play_history: List[datetime]
+    archived: bool = False
 
     def __eq__(self, other):
         if not isinstance(other, GameWithPlayHistory):
@@ -39,6 +40,7 @@ class Game(Base):
     max_players = Column(Integer, nullable=False)
     banner_link = Column(Text, nullable=True)
     playcount_offset = Column(Integer, nullable=False, default=0, server_default="0")
+    archived = Column(Boolean, nullable=False, default=False, server_default="0")
 
     logs = relationship("GameLog", back_populates="game", cascade="all, delete-orphan")
 


### PR DESCRIPTION
<html><head></head><body><h1>PR: Game Archive, Improved Removal &amp; Search Filtering</h1>
<h2>Overview</h2>
<p>This PR introduces three main areas of change:</p>
<ol>
<li>A new <strong>archive/unarchive system</strong> to hide games without deleting them</li>
<li>A safer <strong>remove game flow</strong> requiring a second person's approval</li>
<li><strong>Search filtering</strong> on all <code>get_server_games</code> database functions</li>
</ol>
<hr>
<h2>New Features</h2>
<h3>Archive &amp; Unarchive (<code>cogs/archive_game.py</code>)</h3>
<p>Two new slash commands:</p>
<ul>
<li><strong><code>/archivegame</code></strong> — hides a game from searches and wheel spins without deleting it or its play history</li>
<li><strong><code>/unarchivegame</code></strong> — restores an archived game back into the active pool</li>
</ul>
<p>Both commands follow the same flow:</p>
<ul>
<li>A private ephemeral confirmation embed is sent to the user</li>
<li>On confirmation, the ephemeral message updates to reflect the result, and a <strong>public follow-up is posted</strong> so the channel can see which command was used and who ran it</li>
<li>Autocomplete for <code>/archivegame</code> only shows active (non-archived) games; autocomplete for <code>/unarchivegame</code> only shows archived ones</li>
<li>Both guard against no-op actions (archiving an already-archived game, etc.)</li>
</ul>
<hr>
<h2>Changed Features</h2>
<h3>Remove Game (<code>cogs/remove_game.py</code>)</h3>
<p>The removal flow has been made significantly more destructive-feeling and now <strong>requires approval from a second server member</strong>, matching the pattern used by <code>/nuke</code>:</p>
<ul>
<li>The confirmation message is now <strong>public</strong> rather than ephemeral, so other members can see and act on the request</li>
<li>The requester is <strong>blocked from approving their own request</strong></li>
<li>On approval, the confirmation embed is replaced in-place with a summary showing both <strong>Requested by</strong> and <strong>Approved by</strong></li>
<li>The embed copy makes clear that deletion is permanent, removes play history, and cannot be undone — and signposts <code>/archivegame</code> as a softer alternative</li>
<li>Autocomplete includes archived games so they can still be deleted if needed</li>
</ul>
<hr>
<h2>Database Changes</h2>
<h3>New columns — <code>db/models.py</code></h3>
<p>An <code>archived</code> column has been added to the <code>Game</code> ORM model and the <code>GameWithPlayHistory</code> dataclass (defaults to <code>False</code>).</p>
<h3>Migration — <code>db/migrations/002_add_archived_column.py</code></h3>
<p>An idempotent migration adds the <code>archived INTEGER NOT NULL DEFAULT 0</code> column to the <code>game_list</code> table for existing databases. Runs automatically on bot startup via the existing migration controller.</p>
<h3>New functions — <code>db/database.py</code></h3>

Function | Purpose
-- | --
archive_game_in_db(server_id, name) | Sets archived = True on a game
unarchive_game_in_db(server_id, name) | Sets archived = False on a game
get_archived_server_games(server_id, search?) | Returns only archived games
get_all_server_games_including_archived(server_id, search?) | Returns all games regardless of archive status

</body></html>